### PR TITLE
Improve button debounce handling and resource safety

### DIFF
--- a/button.h
+++ b/button.h
@@ -43,6 +43,7 @@ typedef void (*button_callback_fn)(button_event_t event, void* context);
 // -3 if the repeat-press timer cannot be created.
 // -4 if the GPIO toggle helper cannot be initialised.
 // -5 if the GPIO number is invalid.
+// -6 if the button structure cannot be allocated.
 int button_create(gpio_num_t gpio_num,
                   button_config_t config,
                   button_callback_fn callback,

--- a/toggle.c
+++ b/toggle.c
@@ -3,15 +3,13 @@
 
 #include <stdio.h>
 
+#include <esp_attr.h>
+#include <esp_err.h>
+#include <esp_intr_alloc.h>
 #include <esp_log.h>
 
 #include "toggle.h"
 #include "port.h"
-
-
-#define MAX_TOGGLE_VALUE 4
-#define MIN(a, b) (((b) < (a)) ? (b) : (a))
-#define MAX(a, b) (((a) < (b)) ? (b) : (a))
 
 
 typedef struct _toggle {
@@ -19,22 +17,47 @@ typedef struct _toggle {
         toggle_callback_fn callback;
         void* context;
 
-        // Implementation inspired by
-        // https://github.com/RavenSystem/esp-homekit-devices/blob/master/libs/adv_button/adv_button.c
-        // and
-        // https://github.com/pcsaito/esp-homekit-demo/blob/LPFToggle/examples/sonoff_basic_toggle/toggle.c
-        int8_t value;
         bool last_high;
+        TimerHandle_t debounce_timer;
 
         struct _toggle *next;
 } toggle_t;
 
 
+#define TOGGLE_DEBOUNCE_MS 10
+
+
 static SemaphoreHandle_t toggles_lock = NULL;
 static toggle_t *toggles = NULL;
-static TimerHandle_t toggle_timer = NULL;
 static bool toggles_initialized = false;
 static const char *TAG = "toggle";
+
+
+static void toggle_debounce_timer_callback(TimerHandle_t timer) {
+        toggle_t *toggle = (toggle_t*) pvTimerGetTimerID(timer);
+        if (!toggle)
+                return;
+
+        bool high = my_gpio_read(toggle->gpio_num) == 1;
+        if (high != toggle->last_high) {
+                toggle->last_high = high;
+                toggle->callback(high, toggle->context);
+        }
+}
+
+
+static void IRAM_ATTR toggle_gpio_isr_handler(void *arg) {
+        toggle_t *toggle = (toggle_t*) arg;
+        if (!toggle || !toggle->debounce_timer)
+                return;
+
+        BaseType_t higher_task_woken = pdFALSE;
+        if (xTimerResetFromISR(toggle->debounce_timer, &higher_task_woken) == pdPASS) {
+                if (higher_task_woken == pdTRUE) {
+                        portYIELD_FROM_ISR();
+                }
+        }
+}
 
 
 static toggle_t *toggle_find_by_gpio(const gpio_num_t gpio_num) {
@@ -46,53 +69,35 @@ static toggle_t *toggle_find_by_gpio(const gpio_num_t gpio_num) {
 }
 
 
-static void toggle_timer_callback(TimerHandle_t timer) {
-        if (xSemaphoreTake(toggles_lock, 0) != pdTRUE)
-                return;
-
-        toggle_t *toggle = toggles;
-
-        while (toggle) {
-                if (my_gpio_read(toggle->gpio_num) == 1) {
-                        toggle->value = MIN(toggle->value + 1, MAX_TOGGLE_VALUE);
-                        if (toggle->value == MAX_TOGGLE_VALUE && !toggle->last_high) {
-                                toggle->last_high = true;
-                                toggle->callback(true, toggle->context);
-                        }
-                } else {
-                        toggle->value = MAX(toggle->value - 1, 0);
-                        if (toggle->value == 0 && toggle->last_high) {
-                                toggle->last_high = false;
-                                toggle->callback(false, toggle->context);
-                        }
-                }
-
-                toggle = toggle->next;
-        }
-
-        xSemaphoreGive(toggles_lock);
-}
-
-
 static int toggles_init() {
-        if (!toggles_initialized) {
-                toggles_lock = xSemaphoreCreateBinary();
-                xSemaphoreGive(toggles_lock);
+        if (toggles_initialized)
+                return 0;
 
-                toggle_timer = xTimerCreate(
-                        "Toggle timer", pdMS_TO_TICKS(10), pdTRUE, NULL, toggle_timer_callback
-                        );
+        toggles_lock = xSemaphoreCreateBinary();
+        if (!toggles_lock) {
+                ESP_LOGE(TAG, "Failed to create toggle lock");
+                return -1;
+        }
+        xSemaphoreGive(toggles_lock);
 
-                toggles_initialized = true;
+        esp_err_t err = gpio_install_isr_service(ESP_INTR_FLAG_LOWMED);
+        if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+                ESP_LOGE(TAG, "Failed to install GPIO ISR service: %s", esp_err_to_name(err));
+                vSemaphoreDelete(toggles_lock);
+                toggles_lock = NULL;
+                return -1;
         }
 
+        toggles_initialized = true;
         return 0;
 }
 
 
 int toggle_create(const gpio_num_t gpio_num, toggle_callback_fn callback, void* context) {
-        if (!toggles_initialized)
-                toggles_init();
+        if (!toggles_initialized) {
+                if (toggles_init() != 0)
+                        return -3;
+        }
 
         if (!GPIO_IS_VALID_GPIO(gpio_num)) {
                 ESP_LOGE(TAG, "Invalid GPIO number: %d", (int) gpio_num);
@@ -104,13 +109,54 @@ int toggle_create(const gpio_num_t gpio_num, toggle_callback_fn callback, void* 
                 return -1;
 
         toggle = malloc(sizeof(toggle_t));
+        if (!toggle) {
+                ESP_LOGE(TAG, "Failed to allocate memory for toggle on GPIO %d", (int) gpio_num);
+                return -3;
+        }
+
         memset(toggle, 0, sizeof(*toggle));
         toggle->gpio_num = gpio_num;
         toggle->callback = callback;
         toggle->context = context;
-        toggle->last_high = my_gpio_read(toggle->gpio_num) == 1;
+
+        toggle->debounce_timer = xTimerCreate(
+                "Toggle debounce", pdMS_TO_TICKS(TOGGLE_DEBOUNCE_MS), pdFALSE, toggle, toggle_debounce_timer_callback
+                );
+        if (!toggle->debounce_timer) {
+                ESP_LOGE(TAG, "Failed to create debounce timer for GPIO %d", (int) gpio_num);
+                free(toggle);
+                return -4;
+        }
 
         my_gpio_enable(toggle->gpio_num);
+        toggle->last_high = my_gpio_read(toggle->gpio_num) == 1;
+
+        esp_err_t err = gpio_set_intr_type(toggle->gpio_num, GPIO_INTR_ANYEDGE);
+        if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to set interrupt type for GPIO %d: %s", (int) gpio_num, esp_err_to_name(err));
+                xTimerDelete(toggle->debounce_timer, portMAX_DELAY);
+                free(toggle);
+                return -4;
+        }
+
+        err = gpio_isr_handler_add(toggle->gpio_num, toggle_gpio_isr_handler, toggle);
+        if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to add ISR handler for GPIO %d: %s", (int) gpio_num, esp_err_to_name(err));
+                gpio_set_intr_type(toggle->gpio_num, GPIO_INTR_DISABLE);
+                xTimerDelete(toggle->debounce_timer, portMAX_DELAY);
+                free(toggle);
+                return -4;
+        }
+
+        err = gpio_intr_enable(toggle->gpio_num);
+        if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to enable interrupts for GPIO %d: %s", (int) gpio_num, esp_err_to_name(err));
+                gpio_isr_handler_remove(toggle->gpio_num);
+                gpio_set_intr_type(toggle->gpio_num, GPIO_INTR_DISABLE);
+                xTimerDelete(toggle->debounce_timer, portMAX_DELAY);
+                free(toggle);
+                return -4;
+        }
 
         xSemaphoreTake(toggles_lock, portMAX_DELAY);
 
@@ -119,17 +165,15 @@ int toggle_create(const gpio_num_t gpio_num, toggle_callback_fn callback, void* 
 
         xSemaphoreGive(toggles_lock);
 
-        if (!xTimerIsTimerActive(toggle_timer)) {
-                xTimerStart(toggle_timer, 1);
-        }
-
         return 0;
 }
 
 
 void toggle_delete(const gpio_num_t gpio_num) {
-        if (!toggles_initialized)
-                toggles_init();
+        if (!toggles_initialized) {
+                if (toggles_init() != 0)
+                        return;
+        }
 
         if (!GPIO_IS_VALID_GPIO(gpio_num)) {
                 ESP_LOGE(TAG, "Invalid GPIO number: %d", (int) gpio_num);
@@ -158,14 +202,45 @@ void toggle_delete(const gpio_num_t gpio_num) {
                 }
         }
 
-        if (!toggles) {
-                xTimerStop(toggle_timer, 1);
-        }
-
         xSemaphoreGive(toggles_lock);
 
         if (!toggle)
                 return;
 
+        esp_err_t err = gpio_intr_disable(gpio_num);
+        if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to disable interrupts for GPIO %d: %s", (int) gpio_num, esp_err_to_name(err));
+        }
+
+        err = gpio_isr_handler_remove(gpio_num);
+        if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+                ESP_LOGE(TAG, "Failed to remove ISR handler for GPIO %d: %s", (int) gpio_num, esp_err_to_name(err));
+        }
+        gpio_set_intr_type(gpio_num, GPIO_INTR_DISABLE);
+
+        if (toggle->debounce_timer) {
+                xTimerStop(toggle->debounce_timer, portMAX_DELAY);
+                xTimerDelete(toggle->debounce_timer, portMAX_DELAY);
+        }
+
         free(toggle);
+}
+
+
+void toggle_sync_state(const gpio_num_t gpio_num) {
+        if (!toggles_initialized)
+                return;
+
+        xSemaphoreTake(toggles_lock, portMAX_DELAY);
+
+        toggle_t *toggle = toggle_find_by_gpio(gpio_num);
+        if (toggle) {
+                if (toggle->debounce_timer && xTimerIsTimerActive(toggle->debounce_timer)) {
+                        xTimerStop(toggle->debounce_timer, portMAX_DELAY);
+                }
+
+                toggle->last_high = my_gpio_read(toggle->gpio_num) == 1;
+        }
+
+        xSemaphoreGive(toggles_lock);
 }

--- a/toggle.h
+++ b/toggle.h
@@ -12,10 +12,16 @@
 typedef void (*toggle_callback_fn)(bool high, void* context);
 
 // Function to create a toggle
-// Returns 0 on success, -1 if the GPIO is already tracked, -2 if the GPIO is invalid
+// Returns 0 on success, -1 if the GPIO is already tracked, -2 if the GPIO is invalid,
+// -3 if resources for the toggle cannot be allocated, and -4 if interrupt
+// configuration fails.
 int toggle_create(gpio_num_t gpio_num, toggle_callback_fn callback, void* context);
 
 // Function to delete a toggle
 void toggle_delete(gpio_num_t gpio_num);
+
+// Force the toggle helper to resample and synchronise its state without
+// generating callbacks.
+void toggle_sync_state(gpio_num_t gpio_num);
 
 #endif // TOGGLE_H


### PR DESCRIPTION
## Summary
- switch the GPIO toggle helper from periodic polling to interrupt-driven debouncing with a per-pin timer and synchronization helper
- tighten error handling across button creation, including allocation checks and conditional repeat-timer creation
- document new failure modes for button and toggle helpers

## Testing
- idf.py build *(fails: component lacks standalone project configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d16c7fba688321aadbaca9ae51ee1b